### PR TITLE
bugfix : 新下发的离线包无法下载

### DIFF
--- a/webpackagekit/src/main/java/com/hht/webpackagekit/PackageManager.java
+++ b/webpackagekit/src/main/java/com/hht/webpackagekit/PackageManager.java
@@ -171,6 +171,9 @@ public class PackageManager {
             if (packageInfo.getStatus() == PackageStatus.offLine) {
                 continue;
             }
+            if(TextUtils.isEmpty(packageInfo.getDownloadUrl())){
+                packageInfo.setDownloadUrl(packageInfo.getOrigin_file_path());
+            }
             packageInfoList.add(packageInfo);
         }
         willDownloadPackageInfoList.clear();


### PR DESCRIPTION
当服务器下发要缓存的新的离线包的时候，会因为没有设置DownloadUrl，无法下载